### PR TITLE
Fixed docker CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ COPY --from=builder /op-connect-secret-driver /op-connect-secret-driver
 COPY --from=builder /run/docker/plugins /run/docker/plugins
 
 # Command to run the driver
-CMD ["op-connect-secret-driver"]
+CMD ["/op-connect-secret-driver"]


### PR DESCRIPTION
Fixes the Docker command after the migration to gcr.io/distroless/static-debian12 and change of paths