### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   # --- 1. LINT AND BUILD GO CODE ---
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
@@ -34,6 +36,8 @@ jobs:
 
   # --- 2. BUILD IMAGE AND EXPORT ROOTFS ARTIFACTS ---
   build-and-upload-artifacts:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: lint
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/clementmouchet/op-connect-secret-driver/security/code-scanning/9](https://github.com/clementmouchet/op-connect-secret-driver/security/code-scanning/9)

To fix the flagged issue, you should add a `permissions` block to the jobs that do not currently limit GITHUB_TOKEN permissions. The safest and most minimal starting point is `contents: read`, which allows read access to repository contents but denies any write access. You should place this block within both the `lint` and `build-and-upload-artifacts` jobs (directly beneath the job name for best style, before `runs-on: ...`). This will limit the token’s privileges just for those jobs while leaving the existing broader permissions of the `publish` job untouched. No extra dependencies are required—this is a workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
